### PR TITLE
Bug 1124720: Make test-informant listen for test jobs instead of build jobs

### DIFF
--- a/informant/pulse_listener.py
+++ b/informant/pulse_listener.py
@@ -36,12 +36,8 @@ def on_build_event(data, message):
     platform = '{}-{}'.format(payload['platform'], payload['buildtype'])
 
     skip = None
-    if 'l10n' in payload['tags']:
-        skip = "'l10n' in tags"
-    elif 'nightly' in payload['tags']:
-        skip = "'nightly' in tags"
-    elif not payload['testsurl']:
-        skip = "there is no tests url"
+    if not payload['buildurl']:
+        skip = "there is no build url"
     elif platform not in config.PLATFORMS:
         skip = "platform not configured"
 
@@ -90,7 +86,7 @@ def run(args=sys.argv[1:]):
         worker.start()
 
     label = 'test-informant-{}'.format(uuid.uuid4())
-    topic = 'build.{}.#'.format(settings['BRANCH'])
+    topic = 'unittest.{}.#'.format(settings['BRANCH'])
 
     # defaults
     pulse_args = {


### PR DESCRIPTION
Here's an attempt at using the "buildurl" property (I couldn't find a installer_url property in Pulse Inspector, but the buildurl property looked useful and a Google query brings me to [1]), as described in the bug. There are some unresolved issues, though:
1) Builds whose platform is "emulator" have a "buildurl" pointing to pvtbuilds.pvt.build.mozilla.org, which I can't access. I've commented those platforms out in my config.py file.
2) Besides querying the database, should I also have a dictionary in order to reduce the risk of race conditions?
3) Is there a less hacky way of removing the file extension(s)?
4) Since there usually is no 'tags' argument in payload I had to remove the skip condition to avoid exceptions

[1] https://github.com/dminor/steeplechase-pulselistener/blob/master/steeplechase_pulselistener.py
